### PR TITLE
Fix hsl color parsing error in chart

### DIFF
--- a/src/components/crypto-chart.tsx
+++ b/src/components/crypto-chart.tsx
@@ -71,9 +71,14 @@ const CryptoChart = forwardRef<CryptoChartRef, CryptoChartProps>(
         
       const computedStyle = getComputedStyle(document.documentElement);
       
-      const chartBackgroundColor = `hsl(${computedStyle.getPropertyValue('--card').trim()})`;
-      const textColor = `hsl(${computedStyle.getPropertyValue('--card-foreground').trim()})`;
-      const gridColor = `hsl(${computedStyle.getPropertyValue('--border').trim()})`;
+      // Convert space-separated HSL values to comma-separated format for chart library compatibility
+      const cardHsl = computedStyle.getPropertyValue('--card').trim();
+      const cardForegroundHsl = computedStyle.getPropertyValue('--card-foreground').trim();
+      const borderHsl = computedStyle.getPropertyValue('--border').trim();
+      
+      const chartBackgroundColor = `hsl(${cardHsl.replace(/\s+/g, ', ')})`;
+      const textColor = `hsl(${cardForegroundHsl.replace(/\s+/g, ', ')})`;
+      const gridColor = `hsl(${borderHsl.replace(/\s+/g, ', ')})`;
 
       const handleResize = () => {
         if (chartRef.current) {


### PR DESCRIPTION
Fix color parsing error in TradingView charts by converting space-separated HSL to comma-separated format.

The TradingView Lightweight Charts library expects HSL color values in the traditional `hsl(H, S%, L%)` comma-separated format. However, CSS custom properties were providing modern space-separated HSL values (e.g., `0 0% 98%`). The existing JavaScript code was wrapping these values with `hsl()`, resulting in an invalid `hsl(0 0% 98%)` string that the library could not parse.

---
<a href="https://cursor.com/background-agent?bcId=bc-d42f575a-9bb6-4bd3-a1b3-4112377cf151">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d42f575a-9bb6-4bd3-a1b3-4112377cf151">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

